### PR TITLE
Fix `ZeroDivisionError` crash during time per iter display

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,9 +81,9 @@ def main():
             if ((spsa.t / cutechess.games) % cutechess.save_rate) == 0:
                 print("Saving state...")
                 save_state(spsa)
-            
+
             print(
-                f"iterations: {int(spsa.t / cutechess.games)} ({(avg_time / (spsa.t / cutechess.games - start_t)):.2f}s per iter)")
+                f"iterations: {int(spsa.t / cutechess.games)} ({((avg_time / (spsa.t - start_t)) * cutechess.games):.2f}s per iter)")
             print(
                 f"games: {spsa.t} ({(avg_time / (spsa.t - start_t)):.2f}s per game)")
             for param in spsa.params:
@@ -94,7 +94,7 @@ def main():
         save_state(spsa)
         print("Final results: ")
         print(
-            f"iterations: {int(spsa.t / cutechess.games)} ({(avg_time / (spsa.t / cutechess.games - start_t)):.2f}s per iter)")
+            f"iterations: {int(spsa.t / cutechess.games)} ({((avg_time / (spsa.t - start_t)) * cutechess.games):.2f}s per iter)")
         print(
             f"games: {spsa.t} ({(avg_time / (spsa.t - start_t)):.2f}s per game)")
         print("Final parameters: ")


### PR DESCRIPTION
Multiplication added after the division instead of before to potentially prevent (?) any overflows.

Closes #7 